### PR TITLE
Day11: link CI failure runbook from docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+## Runbooks
+
+- CI failure: `runbooks/ci-failure.md`（Required check: `pr-ci-test`）
+
+
 # Docs
 
 This directory contains operational documents for this repository.


### PR DESCRIPTION
## What changed
- 

## Why
- docs/README に Runbooks セクションを追加し、CI failure runbook へ導線を作成

## Checklist
- [ ] `pr-ci-test` is green
- [ ] No local git tags were created
- [ ] Daily Log was appended at the end of README (one line only)
