### PR TITLE
chore: set job timeouts for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   test:
     name: pr-ci-test
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cut_tag.yml
+++ b/.github/workflows/cut_tag.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   cut_tag:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   release:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Checklist
- [ ] `pr-ci-test` is green
- [ ] No local git tags were created
- [ ] Daily Log was appended at the end of README (one line only)
